### PR TITLE
added new screens to the sidebar

### DIFF
--- a/mobile/src/App.js
+++ b/mobile/src/App.js
@@ -141,6 +141,9 @@ const Drawer = DrawerNavigator(
     Reports: { screen: Reports },
     Teams: { screen: Teams },
     Home: { screen: Home },
+    CreateProject: { screen: CreateProject },
+    ProjectInfo: { screen: ProjectInfo },
+    Requirements: { screen: Requirements },
 
     //dev screens
     Anatomy: { screen: Anatomy },

--- a/mobile/src/util/Auth.js
+++ b/mobile/src/util/Auth.js
@@ -49,7 +49,7 @@ export function userHasPermission(component, permissionID){
     return getPermissions(component).filter(perm => perm.uid === permissionID).length > 0;
 }
 
-export async function setIsLoginStateOnScreenEntry(component, opts={}) {
+export async function setIsLoginStateOnScreenEntry(component, opts = {}) {
     let isClientLoggedIn = await isLoggedIn();
     if (isClientLoggedIn){
         if (component && component.state && !component.state.loggedIn){


### PR DESCRIPTION
Added the CreateProjects, ProjectInfo, and Requirements screens to the sidebar.

This is to fix the issue of this.props.navigation.navigate("DrawerOpen") going back instead of opening the sidebar. Sidebar must have the screens declared to work properly.